### PR TITLE
add missing  __BIG_ENDIAN__ and MSB_FIRST defines to GCN/Wii/Wii U

### DIFF
--- a/src/os/libretro/Makefile
+++ b/src/os/libretro/Makefile
@@ -285,7 +285,7 @@ else ifneq (,$(filter $(platform), ngc wii wiiu))
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
    CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-   CXXFLAGS += -mcpu=750 -meabi -mhard-float -DBLARGG_BIG_ENDIAN=1 -D__ppc__
+   CXXFLAGS += -mcpu=750 -meabi -mhard-float -DBLARGG_BIG_ENDIAN=1 -D__ppc__ -D__BIG_ENDIAN__ -DMSB_FIRST
    CXXFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
    STATIC_LINKING = 1
 


### PR DESCRIPTION
hi there @Ploggy , seeing that you forked stella2023-libretro and i saw you missed a define, which is required for tell Stella we're using it in a big-endian platform.

Try adding these defines i add here for see if this works?